### PR TITLE
RUSTFLAGSを設定することでCPUへの最適化を行う

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN rm -rf /var/lib/apt/lists/*
 
 ENV USER=root
 ENV PATH=/root/.cargo/bin:$PATH
+ENV RUSTFLAGS='-C target-cpu=native'
 
 ARG toolchain
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain "${toolchain}"


### PR DESCRIPTION
参考url https://qiita.com/hakua-doublemoon/items/d99b10c740673b4905d7
`RUSTFLAGS='-C target-cpu=native'`と設定するとビルド時にCPUへの最適化が行われるようです。
手元で実験したところ実行速度が速くなったのを確認しました。